### PR TITLE
Change e-mail address in code of conduct.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at opensource@embark-studios.com. All
+reported by contacting the project team at opensource@traverseresearch.nl. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
The e-mail address in the code of conduct is an embark e-mail address. That is probably because the code of conduct document is based on one found in an open source project by embark. This PR updates it to the Traverse Research address.