### PR TITLE
Update AS descriptor type to KHR final Ray Tracing spec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,8 @@ impl DescriptorType {
     pub const INPUT_ATTACHMENT: Self = Self(10);
 
     pub const INLINE_UNIFORM_BLOCK_EXT: Self = Self(1_000_138_000);
-    pub const ACCELERATION_STRUCTURE_KHR: Self = Self(1_000_165_000);
+    pub const ACCELERATION_STRUCTURE_KHR: Self = Self(1_000_150_000);
+    pub const ACCELERATION_STRUCTURE_NV: Self = Self(1_000_165_000);
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
This depends on rspirv being regenerated with the RT spec: https://github.com/gfx-rs/rspirv/pull/174

We will have to decide on a proper release model for this, assuming not everyone might have updated to official spec yet. Instead of adding an API to keep the NV and KHR number apart which are now different we might expect application users to deal with this in their own code (ie. translating `ACCELERATION_STRUCTURE_KHR` to `ACCELERATION_STRUCTURE_NV`), or we can determine it based on the capability flag `RayTracingNV` vs `RayTracingKHR` which _are_ different values.