### PR TITLE
Fix storage buffer detection in SPIR-V 1.3

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,11 @@ type Result<V, E = ReflectError> = ::std::result::Result<V, E>;
 
 /// These are bit-exact with ash and the Vulkan specification,
 /// they're mirrored here to prevent a dependency on ash
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct DescriptorType(pub u32);
 
+// TODO: Possibly change to a C-like enum to get automatic Debug?
 impl DescriptorType {
     pub const SAMPLER: Self = Self(0);
     pub const COMBINED_IMAGE_SAMPLER: Self = Self(1);
@@ -75,6 +76,28 @@ impl DescriptorType {
     pub const INLINE_UNIFORM_BLOCK_EXT: Self = Self(1_000_138_000);
     pub const ACCELERATION_STRUCTURE_KHR: Self = Self(1_000_150_000);
     pub const ACCELERATION_STRUCTURE_NV: Self = Self(1_000_165_000);
+}
+
+impl std::fmt::Debug for DescriptorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match *self {
+            Self::SAMPLER => "SAMPLER",
+            Self::COMBINED_IMAGE_SAMPLER => "COMBINED_IMAGE_SAMPLER",
+            Self::SAMPLED_IMAGE => "SAMPLED_IMAGE",
+            Self::STORAGE_IMAGE => "STORAGE_IMAGE",
+            Self::UNIFORM_TEXEL_BUFFER => "UNIFORM_TEXEL_BUFFER",
+            Self::STORAGE_TEXEL_BUFFER => "STORAGE_TEXEL_BUFFER",
+            Self::UNIFORM_BUFFER => "UNIFORM_BUFFER",
+            Self::STORAGE_BUFFER => "STORAGE_BUFFER",
+            Self::UNIFORM_BUFFER_DYNAMIC => "UNIFORM_BUFFER_DYNAMIC",
+            Self::STORAGE_BUFFER_DYNAMIC => "STORAGE_BUFFER_DYNAMIC",
+            Self::INPUT_ATTACHMENT => "INPUT_ATTACHMENT",
+            Self::INLINE_UNIFORM_BLOCK_EXT => "INLINE_UNIFORM_BLOCK_EXT",
+            Self::ACCELERATION_STRUCTURE_KHR => "ACCELERATION_STRUCTURE_KHR",
+            Self::ACCELERATION_STRUCTURE_NV => "ACCELERATION_STRUCTURE_NV",
+            _ => "(UNDEFINED)"
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
It's kind of an awkward intermediate version that supports both BufferBlock annotation and storage classes, so support both.

Also implement Debug for DescriptorType to get better debug output when logging out what happened.