### PR TITLE
cargo: Migrate to rspirv 0.10 and the new `spirv` headers crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/Traverse-Research/rspirv-reflect"
 documentation = "https://docs.rs/rspirv-reflect"
 
 [dependencies]
-rspirv = "0.7"
+rspirv = "0.10"
 thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ impl Reflection {
             .collect::<Result<Vec<_>, _>>()?;
 
         let names = reflect
-            .debugs
+            .debug_names
             .iter()
             .filter(|i| i.class.opcode == spirv::Op::Name)
             .map(|i| -> Result<(u32, String)> {


### PR DESCRIPTION
`spirv_headers` is now deprecated and unmaintained in favour of `spirv`.  Updating `rspirv` with this new `spirv` crate in its crate hierarchy solves our denials for unmaintained crates (see [982]), and obviously brings more goodies and improvements along the way.

[982]: https://github.com/rustsec/advisory-db/pull/982
