### PR TITLE
Add OpTypeArray to get_descriptor_type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ impl Reflection {
 
         // Weave with recursive types
         match type_instruction.class.opcode {
-            spirv::Op::TypeRuntimeArray => {
+            spirv::Op::TypeArray | spirv::Op::TypeRuntimeArray => {
                 let element_type_id = get_operand_at!(type_instruction, Operand::IdRef, 0)?;
                 return Ok(DescriptorInfo {
                     is_bindless: true,


### PR DESCRIPTION
The current code errors with `ReflectError::UnhandledTypeInstruction` when dealing with an OpTypeArray:

```
Unhandled OpType instruction Instruction { class: Instruction { opname: "TypeArray", opcode: TypeArray, capabilities: [], operands: [LogicalOperand { kind: IdResult, quantifier: One }, LogicalOperand { kind: IdRef, quantifier: One }, LogicalOperand { kind: IdRef, quantifier: One }] }, result_type: None, result_id: Some(1902), operands: [IdRef(601), IdRef(46)] }
```

I believe handling arrays the same as runtime arrays is probably the right thing to do, but I don't know for sure!