### PR TITLE
Bump rspirv dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/Traverse-Research/rspirv-reflect"
 documentation = "https://docs.rs/rspirv-reflect"
 
 [dependencies]
-rspirv = "0.10"
+rspirv = "0.11"
 thiserror = "1.0"


### PR DESCRIPTION
Just to get rid of the rather slow-to-compile derive_more dependency, which is no longer used in rspirv 0.11.