### PR TITLE
ci: Also run checks on pull request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 name: Continuous integration
 


### PR DESCRIPTION
While Traverse contributions are generally crated from branches on this repository, external contributors submit pull requests from their own forks where the CI does not run.  With this change Github Actions CI runs on both pushes to any branch on this repository as well as every PR submitted against it.

CC #21
