### PR TITLE
Cleanup `get_compute_group_size` function from PR #21

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,18 +216,19 @@ impl Reflection {
 
     pub fn get_compute_group_size(&self) -> Option<(u32, u32, u32)> {
         for inst in self.0.global_inst_iter() {
-            if inst.class.opcode as u32 == 16 {
-                // spirv_headers::Op::ExecutionMode
-                let cs_size = &inst.operands[2..5];
-                use rspirv::dr::Operand::LiteralInt32;
-                if let [LiteralInt32(x), LiteralInt32(y), LiteralInt32(z)] = *cs_size {
+            if inst.class.opcode == spirv::Op::ExecutionMode {
+                use rspirv::dr::Operand::{ExecutionMode, LiteralInt32};
+                if let [ExecutionMode(
+                    spirv::ExecutionMode::LocalSize | spirv::ExecutionMode::LocalSizeHint,
+                ), LiteralInt32(x), LiteralInt32(y), LiteralInt32(z)] = inst.operands[1..]
+                {
                     return Some((x, y, z));
                 } else {
                     // Invalid encoding? Ignoring.
                 }
             }
         }
-        return None;
+        None
     }
 
     /// Returns the descriptor type for a given variable `type_id`

--- a/tests/hlsl.rs
+++ b/tests/hlsl.rs
@@ -9,6 +9,8 @@ fn hlsl_bindings() {
 
     println!("{}", reflect.disassemble());
 
+    assert_eq!(reflect.get_compute_group_size(), Some((64, 1, 1)));
+
     let sets = reflect
         .get_descriptor_sets()
         .expect("Failed to extract descriptor sets");


### PR DESCRIPTION
- Use constant directly instead of hardcoding its value, performing a cast, and commenting the path of the constant below;
- No `return` at the end of a block;
- Validate the execution mode to be `LocalSize` or `LocalSizeHint`;
- Disallow trailing operands after x,y,z size arguments;
- Use this function in the `#[test]` (it is conveniently already testing on a compute shader).

CC @hrydgard