### PR TITLE
Add Send & Sync for ReflectError to support ? with anyhow::Result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,17 @@ impl Reflection {
         None
     }
 
+    pub fn get_execution_model(&self) -> Option<spirv::ExecutionModel>{
+        for inst in self.0.global_inst_iter() {
+            if inst.class.opcode == spirv::Op::EntryPoint {
+                if let rspirv::dr::Operand::ExecutionModel(model) = inst.operands[0] {
+                    return Some(model)
+                }
+            }
+        }
+        None
+    }
+
     /// Returns the descriptor type for a given variable `type_id`
     fn get_descriptor_type_for_var(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,11 +209,11 @@ impl Reflection {
         None
     }
 
-    pub fn get_execution_model(&self) -> Option<spirv::ExecutionModel>{
+    pub fn get_execution_model(&self) -> Option<spirv::ExecutionModel> {
         for inst in self.0.global_inst_iter() {
             if inst.class.opcode == spirv::Op::EntryPoint {
                 if let rspirv::dr::Operand::ExecutionModel(model) = inst.operands[0] {
-                    return Some(model)
+                    return Some(model);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub enum DescriptorType {
 
     InlineUniformBlockEXT = 1_000_138_000,
     AccelerationStructureKHR = 1_000_150_000,
-    AccelerationStructureNV = 1_000_165_000
+    AccelerationStructureNV = 1_000_165_000,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,9 @@ pub enum ReflectError {
     TryFromIntError(#[from] TryFromIntError),
 }
 
+unsafe impl Send for ReflectError {}
+unsafe impl Sync for ReflectError {}
+
 type Result<V, E = ReflectError> = ::std::result::Result<V, E>;
 
 /// These are bit-exact with ash and the Vulkan specification,

--- a/tests/hlsl.rs
+++ b/tests/hlsl.rs
@@ -31,7 +31,7 @@ fn hlsl_bindings() {
         set0[&0],
         DescriptorInfo {
             name: "g_input".to_string(),
-            ty: DescriptorType::STORAGE_BUFFER,
+            ty: DescriptorType::StorageBuffer,
             binding_count: BindingCount::One
         }
     );
@@ -40,7 +40,7 @@ fn hlsl_bindings() {
         set0[&1],
         DescriptorInfo {
             name: "g_output".to_string(),
-            ty: DescriptorType::STORAGE_BUFFER,
+            ty: DescriptorType::StorageBuffer,
             binding_count: BindingCount::One
         }
     );
@@ -49,7 +49,7 @@ fn hlsl_bindings() {
         set0[&2],
         DescriptorInfo {
             name: "g_constant".to_string(),
-            ty: DescriptorType::UNIFORM_BUFFER,
+            ty: DescriptorType::UniformBuffer,
             binding_count: BindingCount::One
         }
     );
@@ -58,7 +58,7 @@ fn hlsl_bindings() {
         set1[&0],
         DescriptorInfo {
             name: "g_bindlessInput".to_string(),
-            ty: DescriptorType::STORAGE_BUFFER,
+            ty: DescriptorType::StorageBuffer,
             binding_count: BindingCount::Unbounded
         }
     );
@@ -67,7 +67,7 @@ fn hlsl_bindings() {
         set2[&0],
         DescriptorInfo {
             name: "g_texture2d".to_string(),
-            ty: DescriptorType::SAMPLED_IMAGE,
+            ty: DescriptorType::SampledImage,
             binding_count: BindingCount::One
         }
     );
@@ -76,7 +76,7 @@ fn hlsl_bindings() {
         set3[&0],
         DescriptorInfo {
             name: "g_rwtexture2d".to_string(),
-            ty: DescriptorType::STORAGE_IMAGE,
+            ty: DescriptorType::StorageImage,
             binding_count: BindingCount::One
         }
     );
@@ -85,7 +85,7 @@ fn hlsl_bindings() {
         set4[&0],
         DescriptorInfo {
             name: "g_bindlessrwtexture2d".to_string(),
-            ty: DescriptorType::STORAGE_IMAGE,
+            ty: DescriptorType::StorageImage,
             binding_count: BindingCount::Unbounded
         }
     );
@@ -94,7 +94,7 @@ fn hlsl_bindings() {
         set5[&0],
         DescriptorInfo {
             name: "g_sampler".to_string(),
-            ty: DescriptorType::SAMPLER,
+            ty: DescriptorType::Sampler,
             binding_count: BindingCount::One
         }
     );
@@ -103,7 +103,7 @@ fn hlsl_bindings() {
         set6[&0],
         DescriptorInfo {
             name: "g_byteAddressBuffer".to_string(),
-            ty: DescriptorType::STORAGE_BUFFER,
+            ty: DescriptorType::StorageBuffer,
             binding_count: BindingCount::Unbounded
         }
     );
@@ -112,7 +112,7 @@ fn hlsl_bindings() {
         set7[&0],
         DescriptorInfo {
             name: "g_rwbyteAddressBuffer".to_string(),
-            ty: DescriptorType::STORAGE_BUFFER,
+            ty: DescriptorType::StorageBuffer,
             binding_count: BindingCount::One
         }
     );
@@ -121,7 +121,7 @@ fn hlsl_bindings() {
         set8[&0],
         DescriptorInfo {
             name: "g_inputArray".to_string(),
-            ty: DescriptorType::STORAGE_BUFFER,
+            ty: DescriptorType::StorageBuffer,
             binding_count: BindingCount::One
         }
     );
@@ -130,7 +130,7 @@ fn hlsl_bindings() {
         set8[&1],
         DescriptorInfo {
             name: "g_arrayOfInputs".to_string(),
-            ty: DescriptorType::STORAGE_BUFFER,
+            ty: DescriptorType::StorageBuffer,
             binding_count: BindingCount::StaticSized(4)
         }
     );
@@ -139,7 +139,7 @@ fn hlsl_bindings() {
         set8[&6],
         DescriptorInfo {
             name: "g_bindlessInputArray".to_string(),
-            ty: DescriptorType::STORAGE_BUFFER,
+            ty: DescriptorType::StorageBuffer,
             binding_count: BindingCount::Unbounded
         }
     );


### PR DESCRIPTION
Hey, 
In the following code does not compile at the moment: 
```Rust
use std::fs::File;
use std::io::Read;
use anyhow::Result;
use rspirv_reflect::Reflection;

fn main() -> Result<()> {
    let mut file = File::open("test.vert.spv")?;

    let mut buffer = Vec::new();
    file.read_to_end(&mut buffer)?;

    let reflection = Reflection::new_from_spirv(&buffer)?;
    let descriptor_sets = reflection.get_descriptor_sets()?;

    println!("{:#?}", descriptor_sets);

    Ok(())
}
```
It fails with ```error[E0277]: `(dyn std::error::Error + Send + 'static)` cannot be shared between threads safely``` 

Therefore, I added Send & Sync for ReflectError to allow support for anyhow::Result. From what I saw, there shouldn't be any error sending ReflectError to multiple threads, correct me please If I'm wrong with this assumption! 