### PR TITLE
Fix library documentation example to be doctested

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 //! Basic SPIR-V reflection library to extract binding information
 //!
-//! ```rustc
-//! let info = Reflection::new_from_spirv(&spirv_blob)?;
-//! dbg!(info.get_descriptor_sets()?);
+//! ```no_run
+//! # let spirv_blob: &[u8] = todo!();
+//! let info = rspirv_reflect::Reflection::new_from_spirv(&spirv_blob).expect("Invalid SPIR-V");
+//! dbg!(info.get_descriptor_sets().expect("Failed to extract descriptor bindings"));
 //! ```
+
 use rspirv::binary::Parser;
 use rspirv::dr::{Instruction, Loader, Module, Operand};
 use std::collections::BTreeMap;


### PR DESCRIPTION
`rustc` is not a valid code identifier, it should have been `rust` (or omitted entirely since this is the default).  Since we have no way of providing a value for `spirv_blob` this example should only be build-tested but not executed, hence `no_run`.
